### PR TITLE
Create missing directories - phase initialize

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -217,6 +217,27 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <tasks>
+                                <mkdir dir="src/main/config"/>
+                                <mkdir dir="target/generated-sources/main/java"/>
+                                <mkdir dir="target/generated-sources/main/resources"/>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
The richfaces cdk maven plugin would complain about these missing
folders and die. Probably best to fix this over there but perhaps
maintaining yet another abandoned project is too big a commitment.

Simply creating the missing directories during initialize phase solves
the build problem.