### PR TITLE
Remove unused methods and corresponding test

### DIFF
--- a/core/src/main/java/org/ajax4jsf/io/FastBufferOutputStream.java
+++ b/core/src/main/java/org/ajax4jsf/io/FastBufferOutputStream.java
@@ -23,7 +23,6 @@ package org.ajax4jsf.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 
 /**
@@ -184,48 +183,6 @@ public class FastBufferOutputStream extends OutputStream {
             out.write(c.getChars(), 0, c.getUsedSize());
             b = b.getNext();
         }
-    }
-
-    /**
-     * Returns instance of FastBufferWriter containing all data written to this output stream.
-     *
-     * @param encoding
-     * @return instance of FastBufferWriter containing all data written to this output stream
-     * @throws UnsupportedEncodingException
-     */
-    public FastBufferWriter convertToWriter(String encoding) throws UnsupportedEncodingException {
-        ByteBuffer c = firstBuffer;
-        CharBuffer first = c.toCharBuffer(encoding);
-        CharBuffer b = first;
-
-        for (c = c.getNext(); c != null; ) {
-            CharBuffer n = c.toCharBuffer(encoding);
-
-            b.setNext(n);
-            b = n;
-        }
-
-        return new FastBufferWriter(first);
-    }
-
-    /**
-     * Returns instance of FastBufferWriter containing all data written to this output stream.
-     *
-     * @return instance of FastBufferWriter containing all data written to this output stream
-     */
-    public FastBufferWriter convertToWriter() {
-        ByteBuffer c = firstBuffer;
-        CharBuffer first = c.toCharBuffer();
-        CharBuffer b = first;
-
-        for (c = c.getNext(); c != null; ) {
-            CharBuffer n = c.toCharBuffer();
-
-            b.setNext(n);
-            b = n;
-        }
-
-        return new FastBufferWriter(first);
     }
 
     /**

--- a/core/src/test/java/org/richfaces/io/io/Test.java
+++ b/core/src/test/java/org/richfaces/io/io/Test.java
@@ -275,45 +275,6 @@ public final class Test {
         }
     }
 
-    static void testTransitionFromStreamToWriter() throws IOException {
-        String s = "This is a senseless text to test transform from stream to writer.\n";
-
-        for (int i = 0; i < 10; i++) {
-            s = s + s; // repeated 16 times
-        }
-
-        byte[] bytes = s.getBytes();
-        FastBufferOutputStream output = new FastBufferOutputStream(16);
-
-        // write it several times.
-        for (int i = 0; i < 4; i++) {
-            output.write(bytes);
-        }
-
-        // write it one more time by one byte
-        for (int i = 0; i < bytes.length; i++) {
-            output.write(bytes[i]);
-        }
-
-        FastBufferWriter output2 = output.convertToWriter("UTF-8");
-        FastBufferReader input = new FastBufferReader(output2.getFirstBuffer());
-        StringBuilder sb = new StringBuilder();
-
-        // use for reading unconvenient array length.
-        char[] bs = new char[ARRAY_LENGTH];
-        int l = 0;
-
-        while ((l = input.read(bs, READ_OFF, READ_LENGTH)) >= 0) {
-            if (BUILD_STRING) {
-                sb.append(new String(bs, READ_OFF, l));
-            }
-        }
-
-        if (BUILD_STRING && OUT_STRING) {
-            System.out.println(sb);
-        }
-    }
-
     /**
      * @param args
      */
@@ -329,8 +290,6 @@ public final class Test {
                 // testStandardReaders();
                 // testTransitionFromWriterToStream();
                 testStandardTransitionFromWriterToStream();
-
-                // testTransitionFromStreamToWriter();
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Initially I wanted to fix a mistake I made in 0e8fca6cd0763f29ef91266e3f954dc9517022e2 but then I realized these methods aren't used anywhere except for a test. So I assume it's safe to remove them.